### PR TITLE
Fix unforcing of chunks when max_player_offline_hours has been exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Requires a 1.7.10 mixin loader like [GTNHMixins](https://github.com/GTNewHorizon
 ## Fixes
 - FTBUtilities (v. 1.7.10-1.0.18.3)
   - Fixes `/sethome` going to bed or spawn in certain scenarios (#1)
+  - Respect the config value for `max_player_offline_hours` and properly unforce chunks when it exceeds (#4)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,6 +34,6 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    implementation(rfg.deobf("curse.maven:ftbutilities-237102:2291494"))
-    implementation(rfg.deobf("curse.maven:ftblib-237167:2291433"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:ftbutilities-237102:2291494"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:ftblib-237167:2291433"))
 }

--- a/src/main/java/uk/bedcraft/bedcraftfixes/mixinplugin/Mixin.java
+++ b/src/main/java/uk/bedcraft/bedcraftfixes/mixinplugin/Mixin.java
@@ -16,8 +16,9 @@ public enum Mixin {
     // Exception: Tags.java, as long as it is used for Strings only!
     //
 
-    // Replace with your own mixins:
-    LMWorldServerMixin("ftbutilities.LMWorldServerMixin", FTB_UTILITIES);
+    // Add Mixins to load here
+    LMWorldServerMixin("ftbutilities.LMWorldServerMixin", FTB_UTILITIES),
+    FTBUChunkEventHandlerMixin("ftbutilities.FTBUChunkEventHandlerMixin", FTB_UTILITIES);
 
     public final String mixinClass;
     public final List<TargetedMod> targetedMods;

--- a/src/main/java/uk/bedcraft/bedcraftfixes/mixins/ftbutilities/FTBUChunkEventHandlerMixin.java
+++ b/src/main/java/uk/bedcraft/bedcraftfixes/mixins/ftbutilities/FTBUChunkEventHandlerMixin.java
@@ -1,0 +1,22 @@
+package uk.bedcraft.bedcraftfixes.mixins.ftbutilities;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import ftb.utils.mod.handlers.FTBUChunkEventHandler;
+import ftb.utils.world.claims.ClaimedChunk;
+
+@Mixin(value = FTBUChunkEventHandler.class, remap = false)
+public abstract class FTBUChunkEventHandlerMixin {
+
+    @ModifyVariable(
+        method = "ticketsLoaded(Ljava/util/List;Lnet/minecraft/world/World;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraftforge/common/ForgeChunkManager;forceChunk(Lnet/minecraftforge/common/ForgeChunkManager$Ticket;Lnet/minecraft/world/ChunkCoordIntPair;)V"))
+    private ClaimedChunk setForced(ClaimedChunk chunk) {
+        chunk.isForced = true;
+        return chunk;
+    }
+}


### PR DESCRIPTION
Due to an oversight in FTB Utilities 1.7.10 chunks are never unforced even if the config value for `max_player_offline_hours` is exceeded.

When a ticket is reloaded after a server restart through `ticketsLoaded` in `FTBUChunkEventHandler`, the `isForced` attribute is never set to true again. When the ticket gets marked for unloading after the offline hours exceed, it is never unforced as the method doesn't know it's forced in the first place.

This Mixin fixes that by setting the `isForced` attribute when a chunk is forced after server restart.