### PR TITLE
Fix crash when frame moves with no players nearby

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Requires a 1.7.10 mixin loader like [GTNHMixins](https://github.com/GTNewHorizon
 - FTBUtilities (v. 1.7.10-1.0.18.3)
   - Fixes `/sethome` going to bed or spawn in certain scenarios (#1)
   - Respect the config value for `max_player_offline_hours` and properly unforce chunks when it exceeds (#4)
+- Funky Locomotion (v. Beta 7)
+  - Fix crash when frame moves with no players nearby ([#5](https://github.com/ThePixelbrain/BedcraftFixes/issues/5))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,4 +36,5 @@
 dependencies {
     devOnlyNonPublishable(rfg.deobf("curse.maven:ftbutilities-237102:2291494"))
     devOnlyNonPublishable(rfg.deobf("curse.maven:ftblib-237167:2291433"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:funkylocomotion-224190:2252223"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ apiPackage =
 # Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
 # There can be multiple files in a comma-separated list.
 # Example value: mymodid_at.cfg,nei_at.cfg
-accessTransformersFile =
+accessTransformersFile = bedcraftfixes_at.cfg
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true

--- a/src/main/java/uk/bedcraft/bedcraftfixes/mixinplugin/Mixin.java
+++ b/src/main/java/uk/bedcraft/bedcraftfixes/mixinplugin/Mixin.java
@@ -18,7 +18,8 @@ public enum Mixin {
 
     // Add Mixins to load here
     LMWorldServerMixin("ftbutilities.LMWorldServerMixin", FTB_UTILITIES),
-    FTBUChunkEventHandlerMixin("ftbutilities.FTBUChunkEventHandlerMixin", FTB_UTILITIES);
+    FTBUChunkEventHandlerMixin("ftbutilities.FTBUChunkEventHandlerMixin", FTB_UTILITIES),
+    MoveManagerMixin("funkylocomotion.MoveManagerMixin", FUNKY_LOCOMOTION);
 
     public final String mixinClass;
     public final List<TargetedMod> targetedMods;

--- a/src/main/java/uk/bedcraft/bedcraftfixes/mixinplugin/TargetedMod.java
+++ b/src/main/java/uk/bedcraft/bedcraftfixes/mixinplugin/TargetedMod.java
@@ -15,7 +15,8 @@ public enum TargetedMod {
 
     // Replace with your injected mods here, but always keep VANILLA:
     VANILLA("Minecraft", "unused", true),
-    FTB_UTILITIES("FTBUtilities", "FTBUtilities", true);
+    FTB_UTILITIES("FTBUtilities", "FTBUtilities", true),
+    FUNKY_LOCOMOTION("FunkyLocomotion", "FunkyLocomotion", true);
 
     public final String modName;
     public final String jarNamePrefixLowercase;

--- a/src/main/java/uk/bedcraft/bedcraftfixes/mixins/funkylocomotion/MoveManagerMixin.java
+++ b/src/main/java/uk/bedcraft/bedcraftfixes/mixins/funkylocomotion/MoveManagerMixin.java
@@ -1,0 +1,23 @@
+package uk.bedcraft.bedcraftfixes.mixins.funkylocomotion;
+
+import net.minecraft.network.Packet;
+import net.minecraft.server.management.PlayerManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+import com.rwtema.funkylocomotion.movers.MoveManager;
+
+@Mixin(value = MoveManager.class, remap = false)
+public abstract class MoveManagerMixin {
+
+    @WrapWithCondition(
+        method = "startMoving",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/management/PlayerManager$PlayerInstance;sendToAllPlayersWatchingChunk(Lnet/minecraft/network/Packet;)V"))
+    private static boolean onlySendWhenNotNull(PlayerManager.PlayerInstance instance, Packet packet) {
+        return instance != null;
+    }
+}

--- a/src/main/resources/META-INF/bedcraftfixes_at.cfg
+++ b/src/main/resources/META-INF/bedcraftfixes_at.cfg
@@ -1,0 +1,2 @@
+# Chunk Watcher (required for Funky Locomotion Mixin)
+public net.minecraft.server.management.PlayerManager$PlayerInstance


### PR DESCRIPTION
Fixes #5

Minecrafts chunk watcher can be null if no player is nearby and Tema didn't account for that, throwing an NPE.
A simple null check fixes this.